### PR TITLE
Added unit tets for Caesar Cipher algorithm

### DIFF
--- a/src/_Classics_/caeser_cipher/caesar-cipher.test.js
+++ b/src/_Classics_/caeser_cipher/caesar-cipher.test.js
@@ -1,0 +1,33 @@
+const { caesarCipher } = require('.');
+
+describe('Caesar Cipher test suit', () => {
+  it('Should raise an error when missing second arg', () => {
+    expect(() => { caesarCipher('hello'); }).toThrowError();
+  });
+
+  it('Should raise an error when second arg is not a num', () => {
+    expect(() => { caesarCipher('hello', 'yes'); }).toThrowError();
+  });
+
+  it('Should return a encrypted word with positive num', () => {
+    expect(caesarCipher('character', 10)).toBe('mrkbkmdob');
+  });
+
+  it('Should return the same word/sentence introduced if num = 0', () => {
+    expect(caesarCipher('character', 0)).toBe('character');
+  });
+
+  it('Should return a encrypted word with negative num', () => {
+    expect(caesarCipher('character', '-10')).toBe('sxqhqsjuh');
+  });
+
+  it('Should reuturn a encrypted sentence with spaces', () => {
+    expect(caesarCipher('another one bite the dust', 15))
+      .toBe('pcdiwtg dct qxit iwt sjhi');
+  });
+
+  it('Should return a encrypted sentence with preserved upper case letters', () => {
+    expect(caesarCipher('Another one Bite the Dust', 15))
+      .toBe('Pcdiwtg dct Qxit iwt Sjhi');
+  });
+});

--- a/src/_Classics_/caeser_cipher/index.js
+++ b/src/_Classics_/caeser_cipher/index.js
@@ -21,7 +21,7 @@ function caesarCipher(str, num) {
     alphabetsMap[alphabets[index]] = index;
   }
 
-  for (let index in lowerCaseString) {
+  for (const index in lowerCaseString) {
     // get the current character
     const currentCharacter = lowerCaseString[index];
 
@@ -59,3 +59,7 @@ function caesarCipher(str, num) {
   }
   return result;
 }
+
+module.exports = {
+  caesarCipher,
+};


### PR DESCRIPTION
There are 2 test failing. One when passing not a number as second argument, included in #44,  the other when passing num = 0. It should return the same word/sentence introduced, but it's raising a 'Missing argument' error. Both issues are related so maybe the last one can be added to #44. 