### PR TITLE
delete() & enhancements in BST

### DIFF
--- a/src/_DataStructures_/Trees/BST/index.js
+++ b/src/_DataStructures_/Trees/BST/index.js
@@ -82,6 +82,10 @@ class BinarySearchTree {
     }
     return false;
   }
+
+  isEmpty() {
+    return this.root === null;
+  }
 }
 
 // const bst = new BinarySearchTree(6);

--- a/src/_DataStructures_/Trees/BST/index.js
+++ b/src/_DataStructures_/Trees/BST/index.js
@@ -104,7 +104,13 @@ class BinarySearchTree {
         // there is a left sub-tree
         return root.leftChild;
       }
-      // the root contain 2 childs
+      /**
+       * the root contain 2 childs, we got 2 options:
+       * 1. We can either find the Node with minimum value at from the right sub-tree
+       * 2. Or, we can find the Node with maximum value from the left sub-tree
+       *
+       * I'm picking up 1 here
+       */
       const minRightNode = this.findMinNode(root.rightChild);
       // eslint-disable-next-line no-param-reassign
       root.value = minRightNode.value;

--- a/src/_DataStructures_/Trees/BST/index.js
+++ b/src/_DataStructures_/Trees/BST/index.js
@@ -83,6 +83,31 @@ class BinarySearchTree {
     return false;
   }
 
+  delete(root, value) {
+    if (root === null) {
+      return root;
+    }
+
+    if (value > root.value) {
+      // eslint-disable-next-line no-param-reassign
+      root.rightChild = this.delete(root.rightChild, value);
+    } else if (value < root.value) {
+      // eslint-disable-next-line no-param-reassign
+      root.leftChild = this.delete(root.leftChild, value);
+    } else {
+      // found the node
+      if (root.leftChild === null) {
+        // there is a right sub-tree
+        return root.rightChild;
+      }
+      if (root.rightChild === null) {
+        // there is a left sub-tree
+        return root.leftChild;
+      }
+    }
+    return root;
+  }
+
   isEmpty() {
     return this.root === null;
   }
@@ -108,29 +133,51 @@ class BinarySearchTree {
   searchFor(value) {
     return this.search(this.root, value);
   }
+
+  remove(value) {
+    return this.delete(this.root, value);
+  }
 }
 
-// const bst = new BinarySearchTree(6);
-// console.log(bst.root);
-// bst.add(4);
-// bst.add(9);
-// bst.add(2);
-// bst.add(5);
-// bst.add(8);
-// bst.add(12);
+const bst = new BinarySearchTree(6);
+console.log(bst.root);
+bst.add(4);
+bst.add(9);
+bst.add(2);
+bst.add(5);
+bst.add(8);
+bst.add(12);
 
-// console.log(bst.root);
+console.log(bst.root);
 
-// const preorder = bst.traversePreorder();
-// console.log('Preorder Traversal - ', preorder);
+const preorder = bst.traversePreorder();
+console.log('Preorder Traversal - ', preorder);
 
-// const inorder = bst.traverseInorder();
-// console.log('Inorder Traversal - ', inorder);
+const inorder = bst.traverseInorder();
+console.log('Inorder Traversal - ', inorder);
 
-// const postorder = bst.traversePostorder();
-// console.log('Postorder Traversal - ', postorder);
+const postorder = bst.traversePostorder();
+console.log('Postorder Traversal - ', postorder);
 
-// const search = 18;
-// console.log(`Search for ${search}`, bst.searchFor(search));
+const search = 18;
+console.log(`Search for ${search}`, bst.searchFor(search));
+
+bst.remove(8);
+console.log(bst.traversePreorder());
+
+bst.remove(5);
+console.log(bst.traversePreorder());
+
+bst.remove(4);
+console.log(bst.traversePreorder());
+
+bst.remove(2);
+console.log(bst.traversePreorder());
+
+bst.remove(9);
+console.log(bst.traversePreorder());
+
+bst.remove(12);
+console.log(bst.traversePreorder());
 
 module.exports = BinarySearchTree;

--- a/src/_DataStructures_/Trees/BST/index.js
+++ b/src/_DataStructures_/Trees/BST/index.js
@@ -86,29 +86,51 @@ class BinarySearchTree {
   isEmpty() {
     return this.root === null;
   }
+
+  /** Layered methods to simplify the BST API  */
+
+  add(value) {
+    return this.insert(this.root, value);
+  }
+
+  traversePreorder() {
+    return this.preorder(this.root);
+  }
+
+  traversePostorder() {
+    return this.postorder(this.root);
+  }
+
+  traverseInorder() {
+    return this.inorder(this.root);
+  }
+
+  searchFor(value) {
+    return this.search(this.root, value);
+  }
 }
 
 // const bst = new BinarySearchTree(6);
 // console.log(bst.root);
-// bst.insert(bst.root, 4);
-// bst.insert(bst.root, 9);
-// bst.insert(bst.root, 2);
-// bst.insert(bst.root, 5);
-// bst.insert(bst.root, 8);
-// bst.insert(bst.root, 12);
+// bst.add(4);
+// bst.add(9);
+// bst.add(2);
+// bst.add(5);
+// bst.add(8);
+// bst.add(12);
 
 // console.log(bst.root);
 
-// const preorder = bst.preorder(bst.root);
+// const preorder = bst.traversePreorder();
 // console.log('Preorder Traversal - ', preorder);
 
-// const inorder = bst.inorder(bst.root);
+// const inorder = bst.traverseInorder();
 // console.log('Inorder Traversal - ', inorder);
 
-// const postorder = bst.postorder(bst.root);
+// const postorder = bst.traversePostorder();
 // console.log('Postorder Traversal - ', postorder);
 
 // const search = 18;
-// console.log(`Search for ${search}`, bst.search(bst.root, search));
+// console.log(`Search for ${search}`, bst.searchFor(search));
 
 module.exports = BinarySearchTree;

--- a/src/_DataStructures_/Trees/BST/index.js
+++ b/src/_DataStructures_/Trees/BST/index.js
@@ -157,44 +157,35 @@ class BinarySearchTree {
   }
 }
 
-const bst = new BinarySearchTree(6);
-console.log(bst.root);
-bst.add(4);
-bst.add(9);
-bst.add(2);
-bst.add(5);
-bst.add(8);
-bst.add(12);
+// const bst = new BinarySearchTree(6);
+// console.log(bst.root);
+// bst.add(4);
+// bst.add(9);
+// bst.add(2);
+// bst.add(5);
+// bst.add(8);
+// bst.add(12);
 
-console.log(bst.root);
+// console.log(bst.root);
 
-const preorder = bst.traversePreorder();
-console.log('Preorder Traversal - ', preorder);
+// const preorder = bst.traversePreorder();
+// console.log('Preorder Traversal - ', preorder);
 
-const inorder = bst.traverseInorder();
-console.log('Inorder Traversal - ', inorder);
+// const inorder = bst.traverseInorder();
+// console.log('Inorder Traversal - ', inorder);
 
-const postorder = bst.traversePostorder();
-console.log('Postorder Traversal - ', postorder);
+// const postorder = bst.traversePostorder();
+// console.log('Postorder Traversal - ', postorder);
 
-const search = 18;
-console.log(`Search for ${search}`, bst.searchFor(search));
+// const search = 18;
+// console.log(`Search for ${search}`, bst.searchFor(search));
 
-const minNode = bst.findMinimum();
-console.log('Minimum value =>', minNode);
+// const minNode = bst.findMinimum();
+// console.log('Minimum value =>', minNode);
 
-bst.remove(4);
-console.log(bst.traversePreorder());
-
-console.log(bst.root);
-
-// bst.remove(2);
+// bst.remove(4);
 // console.log(bst.traversePreorder());
 
-// bst.remove(9);
-// console.log(bst.traversePreorder());
-
-// bst.remove(12);
-// console.log(bst.traversePreorder());
+// console.log(bst.root);
 
 module.exports = BinarySearchTree;

--- a/src/_DataStructures_/Trees/BST/index.js
+++ b/src/_DataStructures_/Trees/BST/index.js
@@ -108,6 +108,12 @@ class BinarySearchTree {
     return root;
   }
 
+  findMinNode(root) {
+    /** The minnimum values is the let most leaf node in BST */
+    if (root.leftChild === null) return root;
+    return this.findMinNode(root.leftChild);
+  }
+
   isEmpty() {
     return this.root === null;
   }
@@ -132,6 +138,11 @@ class BinarySearchTree {
 
   searchFor(value) {
     return this.search(this.root, value);
+  }
+
+  findMinimum() {
+    const minNode = this.findMinNode(this.root);
+    return minNode.value;
   }
 
   remove(value) {
@@ -162,8 +173,12 @@ class BinarySearchTree {
 // const search = 18;
 // console.log(`Search for ${search}`, bst.searchFor(search));
 
+// const minNode = bst.findMinimum();
+// console.log('Minimum value =>', minNode);
+
 // bst.remove(8);
 // console.log(bst.traversePreorder());
+// console.log(bst.root);
 
 // bst.remove(5);
 // console.log(bst.traversePreorder());

--- a/src/_DataStructures_/Trees/BST/index.js
+++ b/src/_DataStructures_/Trees/BST/index.js
@@ -121,6 +121,11 @@ class BinarySearchTree {
     return this.findMinNode(root.leftChild);
   }
 
+  findMaxNode(root) {
+    if (root.rightChild === null) return root;
+    return this.findMaxNode(root.rightChild);
+  }
+
   isEmpty() {
     return this.root === null;
   }
@@ -147,9 +152,14 @@ class BinarySearchTree {
     return this.search(this.root, value);
   }
 
-  findMinimum() {
+  getMinimum() {
     const minNode = this.findMinNode(this.root);
     return minNode.value;
+  }
+
+  getMaximum() {
+    const maxNode = this.findMaxNode(this.root);
+    return maxNode.value;
   }
 
   remove(value) {
@@ -180,8 +190,11 @@ class BinarySearchTree {
 // const search = 18;
 // console.log(`Search for ${search}`, bst.searchFor(search));
 
-// const minNode = bst.findMinimum();
+// const minNode = bst.getMinimum();
 // console.log('Minimum value =>', minNode);
+
+// const maxNode = bst.getMaximum();
+// console.log('Maximum value =>', maxNode);
 
 // bst.remove(4);
 // console.log(bst.traversePreorder());

--- a/src/_DataStructures_/Trees/BST/index.js
+++ b/src/_DataStructures_/Trees/BST/index.js
@@ -109,7 +109,7 @@ class BinarySearchTree {
       // eslint-disable-next-line no-param-reassign
       root.value = minRightNode.value;
       // eslint-disable-next-line no-param-reassign
-      root.rightChild = this.delete(root.rightChild, minRightNode.data);
+      root.rightChild = this.delete(root.rightChild, minRightNode.value);
       return root;
     }
     return root;

--- a/src/_DataStructures_/Trees/BST/index.js
+++ b/src/_DataStructures_/Trees/BST/index.js
@@ -104,6 +104,13 @@ class BinarySearchTree {
         // there is a left sub-tree
         return root.leftChild;
       }
+      // the root contain 2 childs
+      const minRightNode = this.findMinNode(root.rightChild);
+      // eslint-disable-next-line no-param-reassign
+      root.value = minRightNode.value;
+      // eslint-disable-next-line no-param-reassign
+      root.rightChild = this.delete(root.rightChild, minRightNode.data);
+      return root;
     }
     return root;
   }
@@ -150,41 +157,36 @@ class BinarySearchTree {
   }
 }
 
-// const bst = new BinarySearchTree(6);
-// console.log(bst.root);
-// bst.add(4);
-// bst.add(9);
-// bst.add(2);
-// bst.add(5);
-// bst.add(8);
-// bst.add(12);
+const bst = new BinarySearchTree(6);
+console.log(bst.root);
+bst.add(4);
+bst.add(9);
+bst.add(2);
+bst.add(5);
+bst.add(8);
+bst.add(12);
 
-// console.log(bst.root);
+console.log(bst.root);
 
-// const preorder = bst.traversePreorder();
-// console.log('Preorder Traversal - ', preorder);
+const preorder = bst.traversePreorder();
+console.log('Preorder Traversal - ', preorder);
 
-// const inorder = bst.traverseInorder();
-// console.log('Inorder Traversal - ', inorder);
+const inorder = bst.traverseInorder();
+console.log('Inorder Traversal - ', inorder);
 
-// const postorder = bst.traversePostorder();
-// console.log('Postorder Traversal - ', postorder);
+const postorder = bst.traversePostorder();
+console.log('Postorder Traversal - ', postorder);
 
-// const search = 18;
-// console.log(`Search for ${search}`, bst.searchFor(search));
+const search = 18;
+console.log(`Search for ${search}`, bst.searchFor(search));
 
-// const minNode = bst.findMinimum();
-// console.log('Minimum value =>', minNode);
+const minNode = bst.findMinimum();
+console.log('Minimum value =>', minNode);
 
-// bst.remove(8);
-// console.log(bst.traversePreorder());
-// console.log(bst.root);
+bst.remove(4);
+console.log(bst.traversePreorder());
 
-// bst.remove(5);
-// console.log(bst.traversePreorder());
-
-// bst.remove(4);
-// console.log(bst.traversePreorder());
+console.log(bst.root);
 
 // bst.remove(2);
 // console.log(bst.traversePreorder());

--- a/src/_DataStructures_/Trees/BST/index.js
+++ b/src/_DataStructures_/Trees/BST/index.js
@@ -139,45 +139,45 @@ class BinarySearchTree {
   }
 }
 
-const bst = new BinarySearchTree(6);
-console.log(bst.root);
-bst.add(4);
-bst.add(9);
-bst.add(2);
-bst.add(5);
-bst.add(8);
-bst.add(12);
+// const bst = new BinarySearchTree(6);
+// console.log(bst.root);
+// bst.add(4);
+// bst.add(9);
+// bst.add(2);
+// bst.add(5);
+// bst.add(8);
+// bst.add(12);
 
-console.log(bst.root);
+// console.log(bst.root);
 
-const preorder = bst.traversePreorder();
-console.log('Preorder Traversal - ', preorder);
+// const preorder = bst.traversePreorder();
+// console.log('Preorder Traversal - ', preorder);
 
-const inorder = bst.traverseInorder();
-console.log('Inorder Traversal - ', inorder);
+// const inorder = bst.traverseInorder();
+// console.log('Inorder Traversal - ', inorder);
 
-const postorder = bst.traversePostorder();
-console.log('Postorder Traversal - ', postorder);
+// const postorder = bst.traversePostorder();
+// console.log('Postorder Traversal - ', postorder);
 
-const search = 18;
-console.log(`Search for ${search}`, bst.searchFor(search));
+// const search = 18;
+// console.log(`Search for ${search}`, bst.searchFor(search));
 
-bst.remove(8);
-console.log(bst.traversePreorder());
+// bst.remove(8);
+// console.log(bst.traversePreorder());
 
-bst.remove(5);
-console.log(bst.traversePreorder());
+// bst.remove(5);
+// console.log(bst.traversePreorder());
 
-bst.remove(4);
-console.log(bst.traversePreorder());
+// bst.remove(4);
+// console.log(bst.traversePreorder());
 
-bst.remove(2);
-console.log(bst.traversePreorder());
+// bst.remove(2);
+// console.log(bst.traversePreorder());
 
-bst.remove(9);
-console.log(bst.traversePreorder());
+// bst.remove(9);
+// console.log(bst.traversePreorder());
 
-bst.remove(12);
-console.log(bst.traversePreorder());
+// bst.remove(12);
+// console.log(bst.traversePreorder());
 
 module.exports = BinarySearchTree;


### PR DESCRIPTION
🚁 What's inside?

- `remove(value)` which is using `delete(root, value)` at the core  in BST
- Enhancements:
  - replaced `insert(root, value)` with `add(value)`
  - replaced `preorder(root)` with `traversePreorder()`
  - replaced `postorder(root)` with `traversePostorder()`
  - replaced `inorder(root)` with `traverseInorder()`
  - replaced `search(root, value)` with `searchFor(value)`

🔧  Fixes and Updates 
-  fixed delete case of Node having 2 children, thanks @TheSTL for the feedback. 
- `getMinimum()` using `findMinNode(root)`
- `getMaximum()` using `findMaxNode(root)`

🕊 