### PR TITLE
Add unit tests to postfix expression evaluation function. Resolves #34

### DIFF
--- a/src/_DataStructures_/Stack/postfix-expression-evaluation/index.js
+++ b/src/_DataStructures_/Stack/postfix-expression-evaluation/index.js
@@ -15,9 +15,9 @@ function evaluatePostfixExpression(expression) {
             s.push(Number(char));
         } else {
             // if char is an operator then pop two elements from stack, evaluate them accordingly based on operator.
-            //push the result to stack 
+            //push the result to stack
             let val1 = s.pop();
-            let val2 = s.pop()
+            let val2 = s.pop();
             switch (char) {
                 case '+':
                     s.push(val2 + val1);
@@ -38,3 +38,7 @@ function evaluatePostfixExpression(expression) {
     //pop the value of postfix expression
     return s.pop();
 }
+
+module.exports = {
+  evaluatePostfixExpression,
+};

--- a/src/_DataStructures_/Stack/postfix-expression-evaluation/postfix-expression-evaluation.test.js
+++ b/src/_DataStructures_/Stack/postfix-expression-evaluation/postfix-expression-evaluation.test.js
@@ -1,0 +1,55 @@
+const { evaluatePostfixExpression } = require('.');
+
+describe('Postfix expression evaluation', function () {
+  it('should be a function', function () {
+    expect(typeof evaluatePostfixExpression).toEqual('function');
+  });
+  
+  it('should return a number', function () {
+    const expression = '11+';
+    
+    expect(typeof evaluatePostfixExpression(expression)).toEqual('number')
+  });
+  
+  it('should handle addition', function () {
+    const expression = '23+';
+    const expected = 5;
+    
+    expect(evaluatePostfixExpression(expression)).toEqual(expected);
+  });
+  
+  it('should handle subtraction', function () {
+    const expression = '54-';
+    const expected = 1;
+    
+    expect(evaluatePostfixExpression(expression)).toEqual(expected);
+  });
+  
+  it('should handle multiplication', function () {
+    const expression = '34*';
+    const expected = 12;
+    
+    expect(evaluatePostfixExpression(expression)).toEqual(expected);
+  });
+  
+  it('should handle division', function () {
+    const expression = '62/';
+    const expected = 3;
+    
+    expect(evaluatePostfixExpression(expression)).toEqual(expected);
+  });
+  
+  it('should handle negative numbers', function () {
+    const expression = '25-';
+    const expected = -3;
+    
+    expect(evaluatePostfixExpression(expression)).toEqual(expected);
+  });
+  
+  it('should handle multiple operators', function () {
+    const expression = '123*+';
+    const expected = 7;
+    
+    expect(evaluatePostfixExpression(expression)).toEqual(expected);
+  });
+});


### PR DESCRIPTION
The added tests verify what the function is currently able to do, coverage is 100%.
I didn't cover the case of too few number arguments (i.e '1-*') because it returns NaN and I'm not sure if this is the desired output.