### PR TITLE
Add unit tests for Trie/unique-word-count

### DIFF
--- a/src/_DataStructures_/Trees/Trie/unique-word-count/index.js
+++ b/src/_DataStructures_/Trees/Trie/unique-word-count/index.js
@@ -1,6 +1,3 @@
-/* eslint-disable no-unused-vars */
-const Trie = require('../index');
-
 function uniqueWordCount(root) {
   let result = 0;
   if (root.isEndOfWord) {
@@ -13,11 +10,5 @@ function uniqueWordCount(root) {
   }
   return result;
 }
-
-// const words = ['bed', 'ball', 'apple', 'java', 'javascript', 'bed'];
-// const trie = new Trie();
-
-// words.forEach(word => trie.insert(word));
-// console.log(uniqueWordCount(trie.root));
 
 module.exports = uniqueWordCount;

--- a/src/_DataStructures_/Trees/Trie/unique-word-count/index.test.js
+++ b/src/_DataStructures_/Trees/Trie/unique-word-count/index.test.js
@@ -1,0 +1,26 @@
+const Trie = require('../index');
+const uniqueWordCount = require('.');
+
+describe('Trie Unique Word Count', () => {
+  it('counts an empty trie', () => {
+    const trie = new Trie();
+    const wordCount = uniqueWordCount(trie.root);
+    expect(wordCount).toEqual(0);
+  });
+
+  it('counts unique words', () => {
+    const trie = new Trie();
+    const words = ['one', 'two', 'three', 'four'];
+    words.forEach(word => trie.insert(word));
+    const wordCount = uniqueWordCount(trie.root);
+    expect(wordCount).toEqual(4);
+  });
+
+  it('does not count duplicate words', () => {
+    const trie = new Trie();
+    const words = ['one', 'one', 'two', 'three'];
+    words.forEach(word => trie.insert(word));
+    const wordCount = uniqueWordCount(trie.root);
+    expect(wordCount).toEqual(3);
+  });
+});


### PR DESCRIPTION
Closes #135 

Achieves 100% coverage on `Trie/unique-word-count`, follows linter rules, and I believe it covers the important test cases.