### PR TITLE
Balanced parentheses problem

### DIFF
--- a/TOC.md
+++ b/TOC.md
@@ -75,6 +75,7 @@
 - [Maximum Product of Three Numbers](src/_Problems_/max-product-of-3-numbers)
 - [Next Greater for Every Element in an Array](src/_Problems_/next-greater-element)
 - [Compose Largest Number](src/_Problems_/compose-largest-number)
+- [Balanced Parentheses](src/_Problems_/balanced-parentheses)
 
 ### Searching
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -984,23 +984,6 @@
         "unset-value": "^1.0.0"
       }
     },
-    "caller-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "^0.2.0"
-      },
-      "dependencies": {
-        "callsites": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-          "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-          "dev": true
-        }
-      }
-    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",

--- a/src/_Problems_/balanced-parentheses/balanced-parentheses.test.js
+++ b/src/_Problems_/balanced-parentheses/balanced-parentheses.test.js
@@ -1,0 +1,28 @@
+const { balancedParantheses } = require('.');
+
+describe('Balanced parantheses in string', () => {
+  let str1, str2, str3, str4;
+
+  beforeEach(() => {
+    str1 = '(())';
+    str2 = '(((';
+    str3 = ')(';
+    str4 = '((()';
+  });
+
+  it('Should return TRUE for `(())`', () => {
+    expect(balancedParantheses(str1)).toBe(true);
+  });
+
+  it('Should return FALSE for `(((`', () => {
+    expect(balancedParantheses(str2)).toBe(false);
+  });
+
+  it('Should return TRUE for `)(`', () => {
+    expect(balancedParantheses(str3)).toBe(false);
+  });
+
+  it('Should return TRUE for `((()`', () => {
+    expect(balancedParantheses(str4)).toBe(false);
+  });
+});

--- a/src/_Problems_/balanced-parentheses/index.js
+++ b/src/_Problems_/balanced-parentheses/index.js
@@ -11,14 +11,9 @@
  */
 
 function balancedParantheses(string) {
-  return !string.split('').reduce(function(prev, char) {
-    if (prev < 0) return prev;
-
-    if (char === '(') return ++prev;
-
-    if (char === ')') return --prev;
-
-    return prev;
+  return !string.split('').reduce((prev, char) => {
+    const result = prev < 0 ? prev : char === '(' ? ++prev : char === ')' ? --prev : prev;
+    return result;
   }, 0);
 }
 

--- a/src/_Problems_/balanced-parentheses/index.js
+++ b/src/_Problems_/balanced-parentheses/index.js
@@ -1,0 +1,27 @@
+/* 
+    Given a string containing characters and "(" , ")" determine if input string is valid if:
+    -  Open parantheses is closed by same number & type of parantheses.
+    Note that an empty string is also considered valid and any alphanumeric char can be inserted in between pratheses.
+
+    Example : 
+       ((())) is balanced.
+       ((() is not balanced.
+       )( is not balanced.
+    We will solve this problem using ES6 - Array Method reduce().
+ */
+
+function balancedParantheses(string) {
+  return !string.split('').reduce(function(prev, char) {
+    if (prev < 0) return prev;
+
+    if (char === '(') return ++prev;
+
+    if (char === ')') return --prev;
+
+    return prev;
+  }, 0);
+}
+
+module.exports = {
+  balancedParantheses,
+};

--- a/src/_Problems_/balanced-parentheses/index.js
+++ b/src/_Problems_/balanced-parentheses/index.js
@@ -12,8 +12,13 @@
 
 function balancedParantheses(string) {
   return !string.split('').reduce((prev, char) => {
-    const result = prev < 0 ? prev : char === '(' ? ++prev : char === ')' ? --prev : prev;
-    return result;
+    if (prev < 0) return prev;
+
+    if (char === '(') return ++prev;
+
+    if (char === ')') return --prev;
+
+    return prev;
   }, 0);
 }
 


### PR DESCRIPTION
Issue no : #166

- reduce() method for solving balanced parens problem.

since multiple cases are there for checking switch case pattern will create more complexity. So, if else is used.